### PR TITLE
feat: terminado frontend y backend de admin para gestión de citas. 

### DIFF
--- a/backend/fisio_find/gestion_citas/urls.py
+++ b/backend/fisio_find/gestion_citas/urls.py
@@ -5,5 +5,10 @@ from rest_framework.urlpatterns import format_suffix_patterns
 urlpatterns = [
     path('appointment/', views.AppointmentList.as_view()),
     path('appointment/<int:pk>/', views.AppointmentDetail.as_view()),
+    path('appointment/admin/create/', views.AdminAppointmenCreate.as_view()),
+    path('appointment/admin/list/', views.AdminAppointmenList.as_view()),
+    path('appointment/admin/list/<int:pk>/', views.AdminAppointmennDetail.as_view()),
+    path('appointment/admin/edit/<int:pk>/', views.AdminAppointmenUpdate.as_view()),
+    path('appointment/admin/delete/<int:pk>/', views.AdminAppointmenDelete.as_view()),
 ]
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/backend/fisio_find/gestion_citas/views.py
+++ b/backend/fisio_find/gestion_citas/views.py
@@ -3,7 +3,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from gestion_citas.permissions import IsOwner
 from gestion_citas.models import Appointment
 from gestion_citas.serializers import AppointmentSerializer
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import IsAuthenticated
 from gestion_usuarios.permissions import IsAdmin
 
 class AppointmentList(generics.ListCreateAPIView):
@@ -40,7 +40,7 @@ class AdminAppointmennDetail(generics.RetrieveAPIView):
     '''
     API endpoint que retorna un solo término por su id para admin.
     '''
-    permission_classes = [AllowAny]#[IsAdmin]
+    permission_classes = [IsAdmin]
     queryset = Appointment.objects.all()
     serializer_class = AppointmentSerializer
 

--- a/backend/fisio_find/gestion_citas/views.py
+++ b/backend/fisio_find/gestion_citas/views.py
@@ -3,7 +3,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 from gestion_citas.permissions import IsOwner
 from gestion_citas.models import Appointment
 from gestion_citas.serializers import AppointmentSerializer
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from gestion_usuarios.permissions import IsAdmin
 
 class AppointmentList(generics.ListCreateAPIView):
     permission_classes = [IsAuthenticated]
@@ -15,5 +16,46 @@ class AppointmentList(generics.ListCreateAPIView):
 
 class AppointmentDetail(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = [IsAuthenticated, IsOwner]
+    queryset = Appointment.objects.all()
+    serializer_class = AppointmentSerializer
+    
+class AdminAppointmenCreate(generics.CreateAPIView):
+    '''
+    API endpoint para crear un término para admin.
+    '''
+    permission_classes = [IsAdmin]
+    queryset = Appointment.objects.all()
+    serializer_class = AppointmentSerializer
+
+
+class AdminAppointmenList(generics.ListAPIView):
+    '''
+    API endpoint para listar los términos para admin.
+    '''
+    permission_classes = [IsAdmin]
+    queryset = Appointment.objects.all()
+    serializer_class = AppointmentSerializer
+
+class AdminAppointmennDetail(generics.RetrieveAPIView):
+    '''
+    API endpoint que retorna un solo término por su id para admin.
+    '''
+    permission_classes = [AllowAny]#[IsAdmin]
+    queryset = Appointment.objects.all()
+    serializer_class = AppointmentSerializer
+
+class AdminAppointmenUpdate(generics.RetrieveUpdateAPIView):
+    '''
+    API endpoint para que admin actualice un término.
+    '''
+    permission_classes = [IsAdmin]
+    queryset = Appointment.objects.all()
+    serializer_class = AppointmentSerializer
+
+class AdminAppointmenDelete(generics.DestroyAPIView):
+    '''
+    API endpoint para que admin elimine un término.
+    '''
+    permission_classes = [IsAdmin]
     queryset = Appointment.objects.all()
     serializer_class = AppointmentSerializer

--- a/frontend/app/gestion-admin/citas/create/page.tsx
+++ b/frontend/app/gestion-admin/citas/create/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+export default function editarCitas() {
+  const [fechaInicio, setFechaInicio] = useState("");
+  const [fechaFinal, setFechaFinal] = useState("");
+  const [esOnline, setEsOnline] = useState(true);
+  const [servicios, setServicios] = useState("");
+  const [paciente, setPaciente] = useState("");
+  const [fisio, setFisio] = useState("");
+  const [estado, setEstado] = useState("finished")
+  
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    axios.post('http://localhost:8000/api/app_appointment/appointment/admin/create/',{
+      start_time: fechaInicio,
+      end_time: fechaFinal,
+      is_online: esOnline,
+      service: JSON.parse(servicios),
+      patient: paciente,
+      physiotherapist: fisio,
+      status: estado
+    }).then( () => {
+        location.href="/gestion-admin/citas/"
+      })
+      .catch(error => {
+        console.error("Error fetching data:", error);
+    });
+  }
+
+  return (
+    <>
+      <div className="admin-header">
+        <h1>Crear cita</h1>
+      </div>
+      <div className="terminos-container">
+        <form onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="fecha-inicio">Fecha y hora inicio: </label>
+            <input type="datetime-local" id="fecha-inicio" onChange={fechaIn => setFechaInicio(fechaIn.target.value)}/>
+          </div>
+          <div>
+            <label htmlFor="fecha-final">Ficha y hora final: </label>
+            <input type="datetime-local" id="fecha-final" onChange={fechaFin => setFechaFinal(fechaFin.target.value)}/>
+          </div> 
+
+          <div>
+            <label htmlFor="es-online">¿Es la cita online?: </label>
+            <select name="es-online" id="es-online" onChange={online => setEsOnline(online == "true" ? true : false)} >
+              <option value="true">Sí</option>
+              <option value="false">No</option>
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="paciente">ID Paciente: </label>
+            <input type="text" id="paciente"  onChange={paciente => setPaciente(paciente.target.value)} />
+          </div>
+
+          <div>
+            <label htmlFor="fisio">ID Fisioterapeuta: </label>
+            <input type="text" id="fisio"  onChange={fisio => setFisio(fisio.target.value)} />
+          </div>
+
+          <div className="json-service">
+            <label htmlFor="servicios">Servicios:</label>
+            <textarea id="servicios" onChange={serv => setServicios(serv.target.value)}></textarea>
+          </div>
+
+          <div>
+            <label htmlFor="estado-cita">Estado de la cita: </label>
+            <select name="estado-cita" id="estado-cita" onChange={estado_cita => setEstado(estado_cita.target.value)} >
+              <option value="finished">Finalizada</option>
+              <option value="confirmed">Confirmada</option>
+              <option value="canceled">Cancelada</option>
+              <option value="booked">Reservada</option>
+            </select>
+          </div>
+
+          <input type="submit" value="Submit" className="btn-admin" />
+        </form>
+      </div>
+
+    </>
+  );
+}

--- a/frontend/app/gestion-admin/citas/delete/[id]/page.tsx
+++ b/frontend/app/gestion-admin/citas/delete/[id]/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { get_id_from_url } from "@/app/gestion-admin/util";
+
+interface citaInterface {
+  id: string;
+  start_time: string;
+  end_time: string;
+  is_online: string;
+  service: string;
+  physiotherapist: string;
+  patient: string;
+  status: string;
+}
+export default function EliminarCitas() {
+  const id = get_id_from_url()
+
+  const [cita, setCita] = useState<citaInterface | null>(null);
+
+  useEffect(() => {
+    axios.get('http://localhost:8000/api/app_appointment/appointment/admin/list/'+id+'/'
+    ).then(response => {
+        setCita(response.data);
+      })
+      .catch(error => {
+        console.error("Error fetching data:", error);
+      });
+  }, []);
+
+  function deleteCita() {
+    axios.delete('http://localhost:8000/api/app_appointment/appointment/admin/delete/'+id+'/'
+    ).then(() => {
+        location.href="/gestion-admin/citas/"
+      })
+      .catch(error => {
+        console.error("Error fetching data:", error);
+      });
+  }
+
+  return (
+    <>
+      <div className="admin-header">
+        <a href="/gestion-admin/citas/"><button className="btn-admin">Volver</button></a>
+        <h1>Eliminar cita</h1>
+      </div>
+      <div className="admin-header">
+        {cita && <>
+          <p>¿Quieres borrar la cita {cita.id}?</p>
+          <button className="btn-admin-red" onClick={deleteCita}>Sí</button>
+          <button className="btn-admin-green" onClick={() => location.href="/gestion-admin/citas/"}>No</button>
+          </>
+        }
+        {!cita && <h1>Cita no encontrada</h1>
+        }    
+      </div>
+
+    </>
+  );
+}

--- a/frontend/app/gestion-admin/citas/edit/[id]/page.tsx
+++ b/frontend/app/gestion-admin/citas/edit/[id]/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+import {get_id_from_url } from "@/app/gestion-admin/util";
+
+
+interface citaInterface {
+  id: string;
+  start_time: string;
+  end_time: string;
+  is_online: string;
+  service: string;
+  physiotherapist: string;
+  patient: string;
+  status: string;
+}
+
+export default function EditarCitas() {
+
+  const id = get_id_from_url()
+  const [cita, setCita] = useState<citaInterface | null>(null);
+
+  const [fechaInicio, setFechaInicio] = useState("");
+  const [fechaFinal, setFechaFinal] = useState("");
+  const [esOnline, setEsOnline] = useState(true);
+  const [servicios, setServicios] = useState("");
+  const [paciente, setPaciente] = useState("");
+  const [fisio, setFisio] = useState("");
+  const [estado, setEstado] = useState("")
+
+  useEffect(() => {
+    axios.get('http://localhost:8000/api/app_appointment/appointment/admin/list/'+id+'/'
+    ).then(response => {
+        setCita(response.data);
+        setFechaInicio(response.data.start_time.replace("Z",""))
+        setFechaFinal(response.data.end_time.replace("Z",""))
+        setEsOnline(response.data.is_online)
+        setServicios(JSON.stringify(response.data.service))
+        setPaciente(response.data.patient)
+        setFisio(response.data.physiotherapist)
+        setEstado(response.data.status)
+        console.log(response.data)
+      })
+      .catch(error => {
+        console.error("Error fetching data:", error);
+      });
+  }, []);
+
+  function handleSubmit(event) {
+    event.preventDefault();
+
+    axios.put('http://localhost:8000/api/app_appointment/appointment/admin/edit/'+id+'/',{
+      start_time: fechaInicio,
+      end_time: fechaFinal,
+      is_online: esOnline,
+      service: JSON.parse(servicios),
+      patient: paciente,
+      physiotherapist: fisio,
+      status: estado
+    }).then(() => {
+        location.href="/gestion-admin/citas/"
+      })
+      .catch(error => {
+        console.error("Error fetching data:", error);
+    });
+  }
+
+  return (
+    <>
+      <div className="admin-header">
+        <a href="/gestion-admin/citas"><button className="btn-admin">Volver</button></a>
+        <h1>Editar cita</h1>
+      </div>
+      <div className="terminos-container">
+        {cita && <>
+          <form onSubmit={handleSubmit}>
+              <div>
+              <label htmlFor="fecha-inicio">Fecha y hora inicio: </label>
+              <input value={fechaInicio} type="datetime-local" id="fecha-inicio" onChange={fechaIn => setFechaInicio(fechaIn.target.value)}/>
+            </div>
+            <div>
+              <label htmlFor="fecha-final">Ficha y hora final: </label>
+              <input value={fechaFinal} type="datetime-local" id="fecha-final" onChange={fechaFin => setFechaFinal(fechaFin.target.value)}/>
+            </div> 
+
+            <div>
+              <label htmlFor="es-online">¿Es la cita online?: </label>
+              <select value={esOnline ? "true" : "false"} name="es-online" id="es-online" onChange={online => setEsOnline(online == "true" ? true : false)} >
+                <option value="true">Sí</option>
+                <option value="false">No</option>
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="paciente">ID Paciente: </label>
+              <input value={paciente} type="text" id="paciente"  onChange={paciente => setPaciente(paciente.target.value)} />
+            </div>
+
+            <div>
+              <label htmlFor="fisio">ID Fisioterapeuta: </label>
+              <input value={fisio} type="text" id="fisio"  onChange={fisio => setFisio(fisio.target.value)} />
+            </div>
+
+            <div className="json-service">
+              <label htmlFor="servicios">Servicios:</label>
+              <textarea value={servicios} id="servicios" onChange={serv => setServicios(serv.target.value)}></textarea>
+            </div>
+
+            <div>
+              <label htmlFor="estado-cita">Estado de la cita: </label>
+              <select  value={estado} name="estado-cita" id="estado-cita" onChange={estado_cita => setEstado(estado_cita.target.value)} >
+                <option value="finished">Finalizada</option>
+                <option value="confirmed">Confirmada</option>
+                <option value="canceled">Cancelada</option>
+                <option value="booked">Reservada</option>
+              </select>
+            </div>
+            <input type="submit" value="Submit" className="btn-admin" />
+          </form>
+          </>
+        }
+        {!cita && <h1>Cita no encontrada</h1>
+        }   
+      </div>
+    </>
+  );
+}

--- a/frontend/app/gestion-admin/citas/page.tsx
+++ b/frontend/app/gestion-admin/citas/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { print_time } from "../util";
+
+interface citaInterface {
+  id: string;
+  start_time: string;
+  end_time: string;
+  is_online: string;
+  service: string;
+  physiotherapist: string;
+  patient: string;
+  status: string;
+}
+
+const estados_cita = {
+  "finished": "Finalizada",
+  "confirmed": "Confirmada",
+  "canceled": "Cancelada",
+  "booked": "Reservada",
+  "Finished": "Finalizada",
+  "Confirmed": "Confirmada",
+  "Canceled": "Cancelada",
+  "Booked": "Reservada",
+}
+
+
+export default function GestionarCitas() {
+  const [citas, setCitas] = useState<[citaInterface] | null>(null);
+
+  useEffect(() => {
+    axios.get('http://localhost:8000/api/app_appointment/appointment/admin/list/'
+    ).then(response => {
+        setCitas(response.data);
+      })
+      .catch(error => {
+        console.error("Error fetching data:", error);
+      });
+  }, []);
+
+  return (
+    <>
+      <div className="admin-header">
+        <a href="/gestion-admin/"><button className="btn-admin">Volver</button></a>
+        <h1>Página de administración de citas</h1>
+      </div>
+      <div className="terminos-container">
+        <a href="/gestion-admin/citas/create"><button className="btn-admin">Crear</button></a>
+        <div>
+          {citas && 
+            citas.map(function(cita,key) {
+              return <div key={key} className="termino-list-view">
+                <p>Inicio cita: {print_time(cita.start_time)}</p>
+                <p>Final cita: {print_time(cita.end_time)}</p>
+                <p>Es online: {cita.is_online ? "Sí" : "No"}</p>
+                <p>Estado: {estados_cita[cita.status]}</p>
+                
+                <a href={"/gestion-admin/citas/view/"+cita.id}><button className="btn-admin-green">Ver</button></a>
+                <a href={"/gestion-admin/citas/edit/"+cita.id}><button className="btn-admin-yellow">Editar</button></a>
+                <a href={"/gestion-admin/citas/delete/"+cita.id}><button className="btn-admin-red">Eliminar</button></a>
+              </div>
+            })
+          }
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/gestion-admin/citas/view/[id]/page.tsx
+++ b/frontend/app/gestion-admin/citas/view/[id]/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { print_time, get_id_from_url } from "@/app/gestion-admin/util";
+
+
+interface citaInterface {
+  id: string;
+  start_time: string;
+  end_time: string;
+  is_online: string;
+  service: string;
+  physiotherapist: string;
+  patient: string;
+  status: string;
+}
+
+const estados_cita = {
+  "finished": "Finalizada",
+  "confirmed": "Confirmada",
+  "canceled": "Cancelada",
+  "booked": "Reservada",
+  "Finished": "Finalizada",
+  "Confirmed": "Confirmada",
+  "Canceled": "Cancelada",
+  "Booked": "Reservada",
+}
+
+export default function VerCita() {
+  const id = get_id_from_url()
+
+  const [cita, setCita] = useState<citaInterface | null>(null);
+
+  useEffect(() => {
+    axios.get('http://localhost:8000/api/app_appointment/appointment/admin/list/'+id+'/'
+    ).then(response => {
+        setCita(response.data);
+      })
+      .catch(error => {
+        console.error("Error fetching data:", error);
+      });
+  }, []);
+
+  return (
+    <>
+      <div className="admin-header">
+        <a href="/gestion-admin/citas"><button className="btn-admin">Volver</button></a>
+        <h1>Vista de cita</h1>
+      </div>
+      <div className="terminos-container">
+        {cita && <>
+          <p>Inicio cita: {print_time(cita.start_time)}</p>
+          <p>Final cita: {print_time(cita.end_time)}</p>
+          <p>Es online: {cita.is_online ? "Sí" : "No"}</p>
+          <p>Estado: {estados_cita[cita.status]}</p>
+          <p>Id del paciente: {cita.patient} </p>
+          <p>Id del fisioterapeuta: {cita.physiotherapist} </p>
+          <p>Servicios: {JSON.stringify(cita.service)} </p>
+          </>
+        }
+        {!cita && <h1>Cita no encontrada</h1>
+        }    
+      </div>
+
+    </>
+  );
+}

--- a/frontend/app/gestion-admin/page.tsx
+++ b/frontend/app/gestion-admin/page.tsx
@@ -13,6 +13,11 @@ export default function GestionAdmin() {
               <a href="/gestion-admin/terminos"><button className="btn-admin-green">Acceder</button></a>
             </p>
         </div>
+        <div>
+            <p>Panel de gestión de citas
+              <a href="/gestion-admin/citas"><button className="btn-admin-green">Acceder</button></a>
+            </p>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
**Descripción del cambio:**
Terminado frontend y backend de admin para gestión de citas. Falta:
-  Cómo se representa el json de los servicios, porque no está todavía definido.
- Que cuando se seleccionan los usuarios para las citas salga el nombre, porque no está hecha esa funcionalidad para admin todavía.
- Una mejora del estilo, pero esto se hará a todas las vistas de admin a la vez para que se haga de una sola vez.

**Motivación e impacto:**
El administrador de la plataforma debe de poder gestionar las citas.

**Instrucciones**
- Se debe de comprobar que la ruta /admin/citas en el frontend y sus opciones(crear, eliminar, editar, ver, listar) funciona bien.
- En caso de que se quiera probar sin poner el token de admin, se puede cambiar en view.py de gestion-citas el permiso de las rutas a AllowAny momentaneamente.