### PR TITLE
fix: eliminado trigger de workflow de despliegue

### DIFF
--- a/.github/workflows/feat-deploy_fisiofind-backend.yml
+++ b/.github/workflows/feat-deploy_fisiofind-backend.yml
@@ -1,10 +1,10 @@
 name: Build and deploy Python app to Azure Web App - fisiofind-backend
 
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+#on:
+#  push:
+#    branches:
+#      - main
+#  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
**Descripción del cambio:**
Se ha quitado el trigger del workflow de despliegue.
**Motivación e impacto:**
No se quiere que se despliegue cuando se hacen push a main.

**Instrucciones**
- Se debe comprobar si todos los workflows de despliegue se han modificado correctamente.