### PR TITLE
fix: Lógica de colgar arreglada

### DIFF
--- a/frontend/app/videollamadas/Room.jsx
+++ b/frontend/app/videollamadas/Room.jsx
@@ -98,6 +98,11 @@ const Room = ({ roomCode }) => {
             chat.handleChatMessage(data.message);
             break;
           case 'call-ended':
+            console.log("🛑 Recibido call-ended en el paciente, ejecutando handleCallEnded...");
+            roomManagement.handleCallEnded();
+            break;
+          case 'user-disconnected': 
+            console.log("⚠️ Recibido user-disconnected. Cerrando llamada y redirigiendo...");
             roomManagement.handleCallEnded();
             break;
           default:

--- a/frontend/app/videollamadas/hooks/useRoomManagement.js
+++ b/frontend/app/videollamadas/hooks/useRoomManagement.js
@@ -1,113 +1,132 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import axios from 'axios';
 import { getApiBaseUrl } from "@/utils/api";
 
-/**
- * Custom hook for managing room lifecycle
- * @param {Object} options - Configuration options
- * @param {string} options.roomCode - Room ID/code
- * @param {string} options.userRole - User role (physio or patient)
- * @param {Function} options.closeConnection - Function to close WebRTC connection
- * @param {Function} options.cleanupMedia - Function to clean up media resources
- * @param {Function} options.sendWebSocketMessage - Function to send WebSocket messages
- * @param {Function} options.addChatMessage - Function to add a chat message
- * @returns {Object} Room management utilities and state
- */
 const useRoomManagement = ({
   roomCode,
   userRole,
   closeConnection,
   cleanupMedia,
   sendWebSocketMessage,
-  addChatMessage
+  addChatMessage,
+  onCallEndedMessage // ✅ Este callback detectará si el paciente recibe la notificación de cierre
 }) => {
-  // Modal state
+  // Estados para manejar el modal y la eliminación
   const [showModal, setShowModal] = useState(false);
   const [modalMessage, setModalMessage] = useState("");
   const [showDeleteButtons, setShowDeleteButtons] = useState(false);
-  const [waitingForDeletion, setWaitingForDeletion] = useState(false);
   const [isClient, setIsClient] = useState(false);
-  const [token, setToken] = useState < string | null > (null);
 
   useEffect(() => {
     setIsClient(true);
   }, []);
 
-  // End call
-  const endCall = useCallback(async () => {
-    closeConnection();
-    cleanupMedia();
+  const endCall = useCallback(() => {
     addChatMessage('Sistema', 'Has finalizado la llamada');
-
-    // If physio, show action buttons
+  
     if (userRole === 'physio') {
+      // Mostrar el modal antes de cerrar la conexión
       setModalMessage("¿Deseas eliminar la sala de la videollamada?");
       setShowDeleteButtons(true);
       setShowModal(true);
     } else {
-      // If patient, wait for physio confirmation
-      window.location.href = '/videollamadas';
+      // Enviar mensaje WebSocket notificando que el paciente ha salido
+      sendWebSocketMessage({
+        action: 'user-left',
+        message: { role: 'patient' }
+      });
+  
+      // Redirigir al paciente después de un pequeño retraso
+      setTimeout(() => {
+        window.location.href = '/videollamadas';
+      }, 1000);
     }
-  }, [userRole, closeConnection, cleanupMedia, addChatMessage]);
+  }, [userRole, addChatMessage, sendWebSocketMessage]);
+  
 
-  // Confirm room deletion (physio only)
   const confirmDeleteRoom = useCallback(async () => {
-    if (isClient) {
-      const storedToken = localStorage.getItem('token');
-      setToken(storedToken);
-      if (token) {
-        try {
-          const response = await axios.delete(`${getApiBaseUrl()}/api/videocall/delete-room/${roomCode}/`);
-          if (response.status === 204) {
-            console.log('Sala eliminada correctamente');
-            await sendWebSocketMessage({
-              action: 'call-ended',
-              message: { text: 'La llamada ha sido eliminada.' }
-            });
-
-            // Now show modal to patient
-            setModalMessage("La llamada ha finalizado");
-            setShowDeleteButtons(false);
-            setShowModal(true);
-            setWaitingForDeletion(true);
+    if (!isClient) return;
+  
+    try {
+      const storedToken = localStorage.getItem('token'); // Obtiene el token pero no lo almacena
+  
+      // Notificar a todos los usuarios de que la llamada se ha finalizado
+      await sendWebSocketMessage({
+        action: 'call-ended',
+        message: { text: 'La videollamada ha sido finalizada por el fisioterapeuta.' }
+      });
+  
+      // Esperar un poco antes de proceder con la eliminación
+      setTimeout(async () => {
+        const response = await axios.delete(
+          `${getApiBaseUrl()}/api/videocall/delete-room/${roomCode}/`,
+          {
+            headers: {
+              Authorization: `Bearer ${storedToken}` // Usa el token directamente aquí
+            }
           }
-        } catch (error) {
-          console.error('Error eliminando la sala:', error);
+        );
+  
+        if (response.status === 204) {
+          console.log('Sala eliminada correctamente');
+  
+          // Notificar al usuario que la llamada ha finalizado
+          setModalMessage("La llamada ha finalizado");
+          setShowDeleteButtons(false);
+          setShowModal(true);
+  
+          // Cerrar la conexión WebRTC y limpiar recursos
+          closeConnection();
+          cleanupMedia();
+  
+          // Redirigir después de un tiempo
+          setTimeout(() => {
+            window.location.href = '/videollamadas';
+          }, 2000);
         }
-      }
+      }, 1000);
+    } catch (error) {
+      console.error('Error eliminando la sala:', error);
+      setModalMessage("Error eliminando la sala, intenta nuevamente.");
     }
-  }, [roomCode, sendWebSocketMessage, token, isClient]);
+  }, [roomCode, sendWebSocketMessage, closeConnection, cleanupMedia, isClient]);
+  
 
-  // Cancel deletion
   const cancelDelete = useCallback(() => {
     setShowModal(false);
   }, []);
 
-  // Handle call ended message
+  useEffect(() => {
+    if (onCallEndedMessage) {
+      closeConnection();
+      cleanupMedia();
+      window.location.href = '/videollamadas';
+    }
+  }, [onCallEndedMessage, closeConnection, cleanupMedia]);
+
   const handleCallEnded = useCallback(() => {
     setModalMessage("La reunión ha finalizado.");
     setShowModal(true);
-
+  
     setTimeout(() => {
       closeConnection();
       cleanupMedia();
       window.location.href = '/videollamadas';
-    }, 5000);
+    }, 2000);
   }, [closeConnection, cleanupMedia]);
+  
 
   return {
     showModal,
     modalMessage,
     showDeleteButtons,
-    waitingForDeletion,
     setShowModal,
     setModalMessage,
     setShowDeleteButtons,
-    setWaitingForDeletion,
-    endCall,
+    endCall,       
     confirmDeleteRoom,
     cancelDelete,
-    handleCallEnded
+    handleCallEnded      
   };
 };
 

--- a/frontend/app/videollamadas/hooks/useWebRTC.js
+++ b/frontend/app/videollamadas/hooks/useWebRTC.js
@@ -387,6 +387,14 @@ const useWebRTC = ({
         console.log('ICE Candidate recibido:', message);
         handleNewICECandidate(message);
         break;
+      case 'call-ended':
+          console.log('Recibido mensaje de finalización de llamada:', message);
+          setTimeout(() => {
+            closeConnection();
+            window.location.href = '/videollamadas';
+          }, 1500);
+          break;
+        
       
       // Other actions are handled elsewhere
       


### PR DESCRIPTION
**Descripción del cambio:**
Se ha arreglado la lógica de colgar llamadas de la sección videollamadas
- El fisioterapeuta puede colgar tras aceptar en el modal, haciendo que ambos usuarios se salgan. Esto antes no pasaba, puesto que la conexión se cerraba antes de confirmar en el modal, y solo redirigía al fisioterapeuta.
- El paciente puede salir y entrar en la llamada sin problemas, sin que esto afecte a la conexión. Antes, surgían problemas de conexión si el paciente salía y entraba.

**Motivación e impacto:**
- La principal motivación era que lo añadido en videollamadas durante el primer sprint funcionase correctamente.

**Instrucciones**
- Se debe comprobar que el cambio funciona correctamente.