### PR TITLE
Fix: añadida concordancia entre el serializer y el modelo de video

### DIFF
--- a/backend/fisio_find/users/serializers.py
+++ b/backend/fisio_find/users/serializers.py
@@ -523,13 +523,14 @@ class PatientAdminViewSerializer(serializers.ModelSerializer):
 class VideoSerializer(serializers.ModelSerializer):
     file = serializers.FileField(write_only=True)  # Para recibir el archivo en el request
     file_url = serializers.SerializerMethodField()  # Para devolver la URL pública
-    patients = serializers.PrimaryKeyRelatedField(many=True, queryset=Patient.objects.all())  
+    patients = serializers.PrimaryKeyRelatedField(many=True, queryset=Patient.objects.all(), required=False)  
 
     class Meta:
         model = Video
         fields = ["id", "patients", "title", "description", "file", "file_key", "file_url", "uploaded_at"]
         extra_kwargs = {
             "file_key": {"read_only": True},  # El usuario no debe enviar esto
+            "title": {"required": False}, # opcional en update
         }
 
     def validate_file(self, file):
@@ -541,7 +542,9 @@ class VideoSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         """Sube el archivo a DigitalOcean Spaces y guarda el Video en la BD."""
-        file = validated_data.pop("file")  # Extraer archivo del request
+        file = validated_data.pop("file", None)  # Extraer archivo del request
+        if not file:
+            raise serializers.ValidationError("El archivo es requerido para crear un video.")
         physiotherapist = self.context["request"].user.physio  # Usuario logueado
         patients = validated_data.pop("patients", [])
 
@@ -633,4 +636,4 @@ class VideoSerializer(serializers.ModelSerializer):
 
     def get_file_url(self, obj):
         """Devuelve la URL completa del archivo."""
-        return f"{settings.DIGITALOCEAN_ENDPOINT_URL}/{obj.file_key}"
+        return f"https://fisiofind-repo.fra1.digitaloceanspaces.com/{obj.file_key}"


### PR DESCRIPTION
**Descripción del cambio:**
Al realizar los test, se ha descubierto que existe una disparidad entre el modelo y el serializers.
Se han realizado los cambios necesarios para que los test pasen correctamente, se necesita revisar debido a que no tengo el contexto completo de que campos realmente sean obliagatorios u opcionales

**Motivación e impacto:**
- El patients y titulo es opcional
- Comprobar cual es la url esperada de digital ocean

**Instrucciones**
- Estos cambios propuestos pasan las pruebas, pero si estan mal. Se pueden comprobar de la siguiente manera en local si pasan los test.
- Muevase a la rama test-unitarios.
- En la carpeta de backend ejecute este comando en consola (python manage.py test users.tests.VideoSerializerTests)
- Asi comprobara que si los test pasan correctamente despues suba los cambios y borre esta rama